### PR TITLE
Serve robots.txt conditionally to prevent indexing of website mirrors

### DIFF
--- a/application/views.py
+++ b/application/views.py
@@ -15,7 +15,9 @@ from data import models as data_models
 from data import utils as data_utils
 
 import environ
-env = environ.Env()
+env = environ.Env(
+    PRODUCTION_HOST=(str, 'dtp-stat.ru'),
+)
 environ.Env.read_env()
 
 log = logging.getLogger(__name__)
@@ -226,3 +228,11 @@ def temp_map_icons(request, slug):
 
 def old_redirect(request, slug):
     return redirect("home")
+
+
+def robots_txt(request):
+    template = "templates/robots.txt" if request.get_host() == env('PRODUCTION_HOST') else "templates/robots-disallow.txt"
+    f = open(template, "r")
+    file_content = f.read()
+    f.close()
+    return HttpResponse(file_content, content_type="text/plain")

--- a/dtpstat/urls.py
+++ b/dtpstat/urls.py
@@ -27,6 +27,7 @@ from application import views_api as api_views
 
 
 urlpatterns = [
+    path("robots.txt", app_views.robots_txt),
     path('svg/<slug>', app_views.temp_map_icons, name='app.views'),
     path('', app_views.home, name='home'),
     path('accounts/', include('allauth.urls')),

--- a/templates/robots-disallow.txt
+++ b/templates/robots-disallow.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This PR helps migrate pages to Next.js

When we move Django from `dtp-stat.ru` to `django.dtp-stat.ru`, we don’t want the new domain to be indexed. By comparing current request’s host with `PRODUCTION_HOST`, we can serve `robots.txt` conditionally.

Inspired by: https://github.com/dabapps/django-simple-robots

Local tests with [HTTPie](https://httpie.io):

```shell
http http://localhost:5000/robots.txt --body
```

```text
User-agent: *
Disallow: /
```

---

```shell
http http://localhost:5000/robots.txt Host:dtp-stat.ru --body
```

```text
User-agent: *
Disallow: /admin
Disallow: /api
Disallow: /ckeditor
Disallow: /board
Disallow: /accounts
```
