### PR TITLE
fix: display 0 mb in /opendata instead div by 0 (error)

### DIFF
--- a/application/models.py
+++ b/application/models.py
@@ -73,7 +73,9 @@ class OpenData(models.Model):
     file_size = models.IntegerField(null=True, blank=True, default=None)
 
     def mb_file_size(self):
-        return self.file_size/(1024*1024)
+        if self.file_size is None:
+            return 0 # Вернуть вместо ошибки 0 mb, если файл пустой
+        return self.file_size / 1024 / 1024
 
 
 class Ticket(models.Model):


### PR DESCRIPTION
Added handling for the case where the file size is None in the mb_file_size function to avoid a divide-by-zero error. The function now returns 0 MB if the file size is not defined.