### PR TITLE
Bug fix with CRLF line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+manage.py text eol=lf # Для корректной работы внутри Docker


### PR DESCRIPTION
При попытке настроить локальное окружение (в соответсвии с docs/local-env.md) на этапе запуска команды в контейнере
```bash
./manage.py migrate
````
Выдаёт ошибку:
```bash
/usr/bin/env: ‘python\r’: No such file or directory`
```
**Причина:**
Git на Windows задаёт всем файлам перенос строки CRLF (`\r\n`), а для корректной работы bash можно испоьзовать только перенос LF (`\n`)

**Решение:**
Заставить git сохранять `manage.py` на любой системе с помощью `.gitattributes`:
```bash
manage.py text eol=lf 
```

#124
