### PR TITLE
Изменена метка. Добавлен признак что это ZIP, а не просто набор данных

### DIFF
--- a/templates/opendata.html
+++ b/templates/opendata.html
@@ -76,7 +76,7 @@
                     <td class="small">{{ start_date|date:"F Y"|lower }} - {{ opendata_item.date|date:"F Y"|lower }}</td>
                     <td class="small">{{ opendata_item.mb_file_size|floatformat:"2" }} mb</td>
                     <td class="text-center"><a href="/media/opendata/{{ opendata_item.region.slug }}.geojson.zip"
-                                               class="button">Скачать&nbsp;.geojson</a></td>
+                                               class="button">Скачать&nbsp;.geojson.zip</a></td>
                 </tr>
             {% endfor %}
             </tbody>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Open Data download link text to display “.geojson.zip” as the file type, improving clarity for users when downloading datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->